### PR TITLE
[WMSG-219] feat(thread_variables): Add RPCs for managing thread

### DIFF
--- a/im/api/gateway/v1/thread.proto
+++ b/im/api/gateway/v1/thread.proto
@@ -6,6 +6,9 @@ import "buf/validate/validate.proto";
 import "api/gateway/v1/peer.proto";
 import "google/api/annotations.proto";
 import "api/gateway/v1/message_history.proto";
+import "google/protobuf/struct.proto";
+import "api/gateway/v1/contact.proto";
+
 
 // ThreadManagement service provides access to group threads manipulating
 // and read-only access for direct threads.
@@ -26,6 +29,30 @@ service ThreadManagement {
   rpc RemoveMember(RemoveMemberRequest) returns (RemoveMemberResponse) {
     option (google.api.http) = {
       delete: "/v1/threads/{thread_id}/members"
+    };
+  };
+
+  rpc SetVariables(SetVariablesRequest) returns (ThreadVariables) {
+    option (google.api.http) = {
+      post: "/v1/threads/{thread_id}/variables"
+    };
+  };
+
+  rpc SearchVariables(SearchVariablesRequest) returns (SearchVariablesResponse) {
+    option (google.api.http) = {
+      get: "/v1/variables"
+    };
+  };
+
+  rpc LocateVariables(LocateVariablesRequest) returns (ThreadVariables) {
+    option (google.api.http) = {
+      get: "/v1/threads/{thread_id}/variables"
+    };
+  };
+
+  rpc FlushVariables(FlushVariablesRequest) returns (ThreadVariables) {
+    option (google.api.http) = {
+      delete: "/v1/threads/{thread_id}/variables/flush"
     };
   };
 }
@@ -94,6 +121,9 @@ message Thread {
 
     // Last message of the linked thread.
   webitel.im.api.gateway.v1.HistoryMessage last_msg = 11;
+
+  // Optional variables associated with the thread.
+  ThreadVariables variables = 13;
 }
 
 //#endregion
@@ -230,3 +260,56 @@ message RemoveMemberRequest {
 
 message RemoveMemberResponse {
 }
+
+// #region Thread Variables
+
+message VariableEntry {
+    google.protobuf.Struct value = 1;
+    Contact set_by = 2;
+    int64 set_at = 3;
+}
+
+message VariableEntryRequest {
+    string key = 1;
+    google.protobuf.Struct value = 2;
+}
+
+message ThreadVariables {
+    string thread_id = 1;
+    map<string, VariableEntry> variables = 2;
+}
+
+message SetVariablesRequest {
+    string thread_id = 1 [
+        (buf.validate.field).string.uuid = true
+    ];
+    repeated VariableEntryRequest variables = 2;
+}
+
+message SearchVariablesResponse {
+    repeated ThreadVariables items = 1;
+    bool next = 2;
+}
+
+message SearchVariablesRequest {
+    int32 size = 1;
+    int32 page = 2;
+    repeated string fields = 3;
+    repeated string thread_ids = 4;
+}
+
+message LocateVariablesRequest {
+    string thread_id = 1 [
+        (buf.validate.field).string.uuid = true
+    ];
+}
+
+message FlushVariablesRequest {
+    string thread_id = 1 [
+        (buf.validate.field).string.uuid = true
+    ];
+
+    repeated string keys = 2;
+}
+
+// #endregion

--- a/im/api/gateway/v1/thread.proto
+++ b/im/api/gateway/v1/thread.proto
@@ -32,24 +32,33 @@ service ThreadManagement {
     };
   };
 
+  // Sets or updates variables for a specific thread.
+  // Existing variables with the same keys will be overwritten if were setted by the caller.
+  // New variables will be created if they do not exist.
   rpc SetVariables(SetVariablesRequest) returns (ThreadVariables) {
     option (google.api.http) = {
       post: "/v1/threads/{thread_id}/variables"
     };
   };
 
+  // Searches thread variables across multiple threads.
+  // Supports pagination and field projection.
   rpc SearchVariables(SearchVariablesRequest) returns (SearchVariablesResponse) {
     option (google.api.http) = {
       get: "/v1/variables"
     };
   };
 
+  // Retrieves all variables for a specific thread.
   rpc LocateVariables(LocateVariablesRequest) returns (ThreadVariables) {
     option (google.api.http) = {
       get: "/v1/threads/{thread_id}/variables"
     };
   };
 
+  // Removes specified variables from a thread with caller's permission.
+  // If no keys are provided, all variables may be removed
+  // depending on implementation.
   rpc FlushVariables(FlushVariablesRequest) returns (ThreadVariables) {
     option (google.api.http) = {
       delete: "/v1/threads/{thread_id}/variables/flush"
@@ -263,52 +272,104 @@ message RemoveMemberResponse {
 
 // #region Thread Variables
 
+// VariableEntry represents a single variable value
+// along with metadata about who and when it was set.
 message VariableEntry {
+
+    // Arbitrary structured value of the variable.
+    // Supports dynamic JSON-like content.
     google.protobuf.Struct value = 1;
+
+    // Contact who set the variable.
     Contact set_by = 2;
+
+    // Timestamp when the variable was set (Unix time, milliseconds).
     int64 set_at = 3;
 }
 
+// VariableEntryRequest represents a variable update operation.
 message VariableEntryRequest {
+
+    // Variable key.
     string key = 1;
+
+    // Variable value.
     google.protobuf.Struct value = 2;
 }
 
+// ThreadVariables contains all variables associated with a thread.
 message ThreadVariables {
+
+    // Unique identifier for the thread.
     string thread_id = 1;
+
+    // Key-value map of variables.
+    // Key is the variable name, value contains data and metadata.
     map<string, VariableEntry> variables = 2;
 }
 
+// SetVariablesRequest defines parameters
+// for setting or updating thread variables.
 message SetVariablesRequest {
+
+    // Unique identifier for the thread.
     string thread_id = 1 [
         (buf.validate.field).string.uuid = true
     ];
+
+    // List of variables to set or update.
+    // Existing variables with the same keys will be overwritten.
     repeated VariableEntryRequest variables = 2;
 }
 
+// SearchVariablesResponse contains search results
+// and pagination metadata.
 message SearchVariablesResponse {
+
+    // List of thread variables grouped by thread.
     repeated ThreadVariables items = 1;
+
+    // Indicates if there are more results to fetch.
     bool next = 2;
 }
 
+// SearchVariablesRequest defines parameters
+// for searching thread variables.
 message SearchVariablesRequest {
+
+    // Number of results to return per page.
     int32 size = 1;
+
+    // Page number (1-based).
     int32 page = 2;
+
+    // List of fields to include in the response.
     repeated string fields = 3;
+
+    // List of thread IDs to filter by.
     repeated string thread_ids = 4;
 }
 
+// LocateVariablesRequest defines parameters
+// for locating thread variables by thread ID.
 message LocateVariablesRequest {
+
+    // Unique identifier for the thread.
     string thread_id = 1 [
         (buf.validate.field).string.uuid = true
     ];
 }
 
+// FlushVariablesRequest defines parameters
+// for flushing thread variables by thread ID.
 message FlushVariablesRequest {
+
+    // Unique identifier for the thread.
     string thread_id = 1 [
         (buf.validate.field).string.uuid = true
     ];
 
+    // List of variable keys to flush.
     repeated string keys = 2;
 }
 

--- a/im/service/thread/v1/thread_service.proto
+++ b/im/service/thread/v1/thread_service.proto
@@ -313,6 +313,10 @@ message SetVariablesRequest {
         (buf.validate.field).string.uuid = true
     ];
     repeated VariableEntryRequest variables = 2;
+    string member_id = 3 [
+        (buf.validate.field).string.uuid = true
+    ];
+
 }
 
 message SearchVariablesResponse {
@@ -338,7 +342,11 @@ message FlushVariablesRequest {
         (buf.validate.field).string.uuid = true
     ];
 
-    repeated string keys = 2;
+    string member_id = 2 [
+        (buf.validate.field).string.uuid = true
+    ];
+
+    repeated string keys = 3;
 }
 
 // #endregion

--- a/im/service/thread/v1/thread_service.proto
+++ b/im/service/thread/v1/thread_service.proto
@@ -34,13 +34,13 @@ service ThreadManagement {
 
   rpc RemoveMember(RemoveMemberRequest) returns (RemoveMemberResponse);
 
-    rpc SetVariables(SetVariablesRequest) returns (ThreadVariables);
+  rpc SetVariables(SetVariablesRequest) returns (ThreadVariables);
 
-    rpc SearchVariables(SearchVariablesRequest) returns (SearchVariablesResponse);
+  rpc SearchVariables(SearchVariablesRequest) returns (SearchVariablesResponse);
 
-    rpc LocateVariables(LocateVariablesRequest) returns (ThreadVariables);
+  rpc LocateVariables(LocateVariablesRequest) returns (ThreadVariables);
 
-    rpc FlushVariables(FlushVariablesRequest) returns (ThreadVariables);
+  rpc FlushVariables(FlushVariablesRequest) returns (ThreadVariables);
 }
 
 //#region Common
@@ -89,10 +89,11 @@ message Thread {
     // Detailed member information.
   repeated ThreadMember members = 11;
 
-    // Last message of the linked thread.
-    webitel.im.service.thread.v1.HistoryMessage last_msg = 12;
+  // Last message of the linked thread.
+  webitel.im.service.thread.v1.HistoryMessage last_msg = 12;
 
-    ThreadVariables variables = 13;
+  // Optional variables associated with the thread.
+  ThreadVariables variables = 13;
 }
 
 //#endregion
@@ -312,9 +313,6 @@ message SetVariablesRequest {
         (buf.validate.field).string.uuid = true
     ];
     repeated VariableEntryRequest variables = 2;
-    string member_id = 3 [
-        (buf.validate.field).string.uuid = true
-    ];
 }
 
 message SearchVariablesResponse {
@@ -340,11 +338,7 @@ message FlushVariablesRequest {
         (buf.validate.field).string.uuid = true
     ];
 
-    string member_id = 2 [
-        (buf.validate.field).string.uuid = true
-    ];
-
-    repeated string keys = 3;
+    repeated string keys = 2;
 }
 
 // #endregion

--- a/swagger/im-gateway.swagger.json
+++ b/swagger/im-gateway.swagger.json
@@ -881,6 +881,162 @@
         ]
       }
     },
+    "/v1/threads/{thread_id}/variables": {
+      "get": {
+        "operationId": "ThreadManagement_LocateVariables",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "webitel.im.api.gateway.v1.ThreadManagement"
+        ]
+      },
+      "post": {
+        "operationId": "ThreadManagement_SetVariables",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "webitel.im.api.gateway.v1.ThreadManagement"
+        ]
+      }
+    },
+    "/v1/threads/{thread_id}/variables/flush": {
+      "delete": {
+        "operationId": "ThreadManagement_FlushVariables",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "keys",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "webitel.im.api.gateway.v1.ThreadManagement"
+        ]
+      }
+    },
+    "/v1/variables": {
+      "get": {
+        "operationId": "ThreadManagement_SearchVariables",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/webitel.im.api.gateway.v1.SearchVariablesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "thread_ids",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "webitel.im.api.gateway.v1.ThreadManagement"
+        ]
+      }
+    },
     "/v1/{thread_id_1}/messages": {
       "get": {
         "summary": "Search for messages in a thread.",
@@ -2144,6 +2300,21 @@
       },
       "description": "SearchThreadResponse contains the list of threads\nand pagination metadata."
     },
+    "webitel.im.api.gateway.v1.SearchVariablesResponse": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables"
+          }
+        },
+        "next": {
+          "type": "boolean"
+        }
+      }
+    },
     "webitel.im.api.gateway.v1.SendContactRequest": {
       "type": "object",
       "properties": {
@@ -2374,6 +2545,10 @@
         "last_msg": {
           "$ref": "#/definitions/webitel.im.api.gateway.v1.HistoryMessage",
           "description": "Last message of the linked thread."
+        },
+        "variables": {
+          "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables",
+          "description": "Optional variables associated with the thread."
         }
       },
       "description": "Thread represents a thread (aka chat or conversation) entity."
@@ -2442,6 +2617,20 @@
         "ROLE_SUPERVISOR"
       ],
       "default": "ROLE_UNSPECIFIED"
+    },
+    "webitel.im.api.gateway.v1.ThreadVariables": {
+      "type": "object",
+      "properties": {
+        "thread_id": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/webitel.im.api.gateway.v1.VariableEntry"
+          }
+        }
+      }
     },
     "webitel.im.api.gateway.v1.TokenRequest": {
       "type": "object",
@@ -2523,6 +2712,32 @@
         }
       },
       "title": "[User-Agent] string \u0026 details"
+    },
+    "webitel.im.api.gateway.v1.VariableEntry": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "object"
+        },
+        "set_by": {
+          "$ref": "#/definitions/webitel.im.api.gateway.v1.Contact"
+        },
+        "set_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "webitel.im.api.gateway.v1.VariableEntryRequest": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "object"
+        }
+      }
     },
     "webitel.im.api.gateway.v1.WebPushSubscription": {
       "type": "object",

--- a/swagger/im-gateway.swagger.json
+++ b/swagger/im-gateway.swagger.json
@@ -883,6 +883,7 @@
     },
     "/v1/threads/{thread_id}/variables": {
       "get": {
+        "summary": "Retrieves all variables for a specific thread.",
         "operationId": "ThreadManagement_LocateVariables",
         "responses": {
           "200": {
@@ -901,6 +902,7 @@
         "parameters": [
           {
             "name": "thread_id",
+            "description": "Unique identifier for the thread.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -911,6 +913,7 @@
         ]
       },
       "post": {
+        "summary": "Sets or updates variables for a specific thread.\nExisting variables with the same keys will be overwritten if were setted by the caller.\nNew variables will be created if they do not exist.",
         "operationId": "ThreadManagement_SetVariables",
         "responses": {
           "200": {
@@ -929,6 +932,7 @@
         "parameters": [
           {
             "name": "thread_id",
+            "description": "Unique identifier for the thread.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -941,6 +945,7 @@
     },
     "/v1/threads/{thread_id}/variables/flush": {
       "delete": {
+        "summary": "Removes specified variables from a thread with caller's permission.\nIf no keys are provided, all variables may be removed\ndepending on implementation.",
         "operationId": "ThreadManagement_FlushVariables",
         "responses": {
           "200": {
@@ -959,12 +964,14 @@
         "parameters": [
           {
             "name": "thread_id",
+            "description": "Unique identifier for the thread.",
             "in": "path",
             "required": true,
             "type": "string"
           },
           {
             "name": "keys",
+            "description": "List of variable keys to flush.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -981,6 +988,7 @@
     },
     "/v1/variables": {
       "get": {
+        "summary": "Searches thread variables across multiple threads.\nSupports pagination and field projection.",
         "operationId": "ThreadManagement_SearchVariables",
         "responses": {
           "200": {
@@ -999,6 +1007,7 @@
         "parameters": [
           {
             "name": "size",
+            "description": "Number of results to return per page.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -1006,6 +1015,7 @@
           },
           {
             "name": "page",
+            "description": "Page number (1-based).",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -1013,6 +1023,7 @@
           },
           {
             "name": "fields",
+            "description": "List of fields to include in the response.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -1023,6 +1034,7 @@
           },
           {
             "name": "thread_ids",
+            "description": "List of thread IDs to filter by.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -2308,12 +2320,15 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/webitel.im.api.gateway.v1.ThreadVariables"
-          }
+          },
+          "description": "List of thread variables grouped by thread."
         },
         "next": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Indicates if there are more results to fetch."
         }
-      }
+      },
+      "description": "SearchVariablesResponse contains search results\nand pagination metadata."
     },
     "webitel.im.api.gateway.v1.SendContactRequest": {
       "type": "object",
@@ -2622,15 +2637,18 @@
       "type": "object",
       "properties": {
         "thread_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Unique identifier for the thread."
         },
         "variables": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/webitel.im.api.gateway.v1.VariableEntry"
-          }
+          },
+          "description": "Key-value map of variables.\nKey is the variable name, value contains data and metadata."
         }
-      }
+      },
+      "description": "ThreadVariables contains all variables associated with a thread."
     },
     "webitel.im.api.gateway.v1.TokenRequest": {
       "type": "object",
@@ -2717,27 +2735,34 @@
       "type": "object",
       "properties": {
         "value": {
-          "type": "object"
+          "type": "object",
+          "description": "Arbitrary structured value of the variable.\nSupports dynamic JSON-like content."
         },
         "set_by": {
-          "$ref": "#/definitions/webitel.im.api.gateway.v1.Contact"
+          "$ref": "#/definitions/webitel.im.api.gateway.v1.Contact",
+          "description": "Contact who set the variable."
         },
         "set_at": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Timestamp when the variable was set (Unix time, milliseconds)."
         }
-      }
+      },
+      "description": "VariableEntry represents a single variable value\nalong with metadata about who and when it was set."
     },
     "webitel.im.api.gateway.v1.VariableEntryRequest": {
       "type": "object",
       "properties": {
         "key": {
-          "type": "string"
+          "type": "string",
+          "description": "Variable key."
         },
         "value": {
-          "type": "object"
+          "type": "object",
+          "description": "Variable value."
         }
-      }
+      },
+      "description": "VariableEntryRequest represents a variable update operation."
     },
     "webitel.im.api.gateway.v1.WebPushSubscription": {
       "type": "object",


### PR DESCRIPTION
variables and updates to Thread.proto

Add new service endpoints to manage thread variables, including setting, searching, locating, and flushing. Update the `Thread` message to include optional variables field.