### PR TITLE
WTEL-7795: Hide read-only fields from POST/PUT/PATCH /users body

### DIFF
--- a/swagger/webitel-go.swagger.json
+++ b/swagger/webitel-go.swagger.json
@@ -14561,29 +14561,35 @@
                 "created_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "created_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "updated_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "updated_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "deleted_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "deleted_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "chat_name": {
                   "type": "string",
@@ -14733,29 +14739,35 @@
                 "created_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "created_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "updated_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "updated_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "deleted_at": {
                   "type": "string",
                   "format": "int64",
-                  "title": "unix"
+                  "title": "unix",
+                  "readOnly": true
                 },
                 "deleted_by": {
                   "$ref": "#/definitions/apiUserId",
-                  "title": "user"
+                  "title": "user",
+                  "readOnly": true
                 },
                 "chat_name": {
                   "type": "string",
@@ -16528,11 +16540,11 @@
         },
         "user_password": {
           "type": "string",
-          "title": "cleartext passphrase"
+          "readOnly": true
         },
         "confirm_password": {
           "type": "string",
-          "title": "cleartext passphrase"
+          "readOnly": true
         }
       }
     },
@@ -18609,7 +18621,8 @@
         "id": {
           "type": "string",
           "format": "int64",
-          "title": "Object ID"
+          "title": "Object ID",
+          "readOnly": true
         },
         "name": {
           "type": "string",
@@ -18698,29 +18711,35 @@
         "created_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix"
+          "title": "unix",
+          "readOnly": true
         },
         "created_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user"
+          "title": "user",
+          "readOnly": true
         },
         "updated_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix"
+          "title": "unix",
+          "readOnly": true
         },
         "updated_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user"
+          "title": "user",
+          "readOnly": true
         },
         "deleted_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix"
+          "title": "unix",
+          "readOnly": true
         },
         "deleted_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user"
+          "title": "user",
+          "readOnly": true
         },
         "chat_name": {
           "type": "string",

--- a/webitel-go/users.proto
+++ b/webitel-go/users.proto
@@ -11,6 +11,7 @@ import "permission.proto";
 import "auth.proto";
 import "warnings.proto";
 import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
 
 service Users {
 
@@ -94,7 +95,9 @@ message UserId {
 // User profile.
 message User {
 
-    int64  id = 1;   // Object ID
+    int64  id = 1 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // Object ID
     string name = 2; // Caller-ID-Name: Display Name
 
     string email = 3;
@@ -131,12 +134,24 @@ message User {
     // repeated Registration reged = 13; // order by register_last
     ObjectId contact = 18; // [optional] contact connected to this user
 
-    int64  created_at = 20; // unix
-    UserId created_by = 21; // user
-    int64  updated_at = 22; // unix
-    UserId updated_by = 23; // user
-    int64  deleted_at = 24; // unix
-    UserId deleted_by = 25; // user
+    int64  created_at = 20 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // unix
+    UserId created_by = 21 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // user
+    int64  updated_at = 22 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // unix
+    UserId updated_by = 23 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // user
+    int64  deleted_at = 24 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // unix
+    UserId deleted_by = 25 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ]; // user
 
     // The "chat_name" field is used to store the name displayed externally on the platform.
     // For example, "chat_name" is shown when an agent connects to chats with clients.
@@ -148,9 +163,13 @@ message User {
 }
 
 message CreateUserRequest {
-    User   user = 1;       // user entity to be created
-    string user_password = 2; // cleartext passphrase
-    string confirm_password = 3; // cleartext passphrase
+    User   user = 1; // user entity to be created
+    string user_password = 2 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ];
+    string confirm_password = 3 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
+    ];
 }
 
 message CreateUserResponse {


### PR DESCRIPTION
## Проблема
У Swagger UI для ендпоінту `POST /users` у дефолтному прикладі body відображались зайві поля, які клієнт не має надсилати:
- На верхньому рівні `CreateUserRequest`: `user_password`, `confirm_password`
- Усередині вкладеного `user`: `id`, `created_at`, `created_by`, `updated_at`, `updated_by`, `deleted_at`, `deleted_by`

Та сама проблема відтворювалась на `PUT /users/{user.id}` і `PATCH /users/{user.id}`, бо там використовується той самий тип `User`.

## Вирішення
Додано анотацію `read_only: true` через розширення `grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field` на проблемні поля.

Через те, що тип `User` спільний, одна правка автоматично закриває всі три ендпоінти: `POST /users`, `PUT /users/{user.id}`, `PATCH /users/{user.id}`.
