### PR TITLE
WTEL-7795: Introduce InputUser to remove read-only fields

### DIFF
--- a/swagger/webitel-go.swagger.json
+++ b/swagger/webitel-go.swagger.json
@@ -14039,6 +14039,106 @@
         "tags": [
           "Users"
         ]
+      },
+      "put": {
+        "operationId": "UpdateUser",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/apiUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "path: /users/{id}",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "user",
+            "description": "body: modifications/changes",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiInputUser"
+            }
+          },
+          {
+            "name": "fields",
+            "description": "PATCH: partial update",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUser2",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/apiUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "path: /users/{id}",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "user",
+            "description": "body: modifications/changes",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiInputUser"
+            }
+          },
+          {
+            "name": "fields",
+            "description": "PATCH: partial update",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/logout": {
@@ -14437,364 +14537,6 @@
         ],
         "tags": [
           "UserAccessTokens"
-        ]
-      }
-    },
-    "/users/{user.id}": {
-      "put": {
-        "operationId": "UpdateUser",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/apiUser"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "user.id",
-            "description": "Object ID",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "format": "int64"
-          },
-          {
-            "name": "user",
-            "description": "body: modifications/changes",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "title": "Caller-ID-Name: Display Name"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string",
-                  "title": "alphanumeric username (login)"
-                },
-                "password": {
-                  "type": "string"
-                },
-                "extension": {
-                  "type": "string",
-                  "title": "Caller-ID-Number:"
-                },
-                "presence": {
-                  "$ref": "#/definitions/apiUserPresence",
-                  "description": "string presence = 7; // unique set of \u003cuser\u003e presentity \u003cstatus:basic\u003e tuples open[ed]\n string status = 8; // short display status (short description)",
-                  "title": "CallerId caller = 5; // extension\nPresenceStatus presence = 8;"
-                },
-                "device": {
-                  "$ref": "#/definitions/apiObjectId",
-                  "title": "[optional] default device assigned ? WebRTC register ?"
-                },
-                "devices": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "description": "[editable] list of unique `regular` devices, attached to this user",
-                  "title": "map\u003cint64, string\u003e devices = 13;"
-                },
-                "hotdesks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "title": "[readonly] list of unique `hotdesk` devices, assigned to this user"
-                },
-                "profile": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "list of variables, assigned to this user as an environment unit"
-                },
-                "permissions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiPermission"
-                  },
-                  "title": "set of operational permission grants"
-                },
-                "license": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiLicenseUser"
-                  },
-                  "title": "list of unique licenses, granted to this user"
-                },
-                "roles": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "title": "roles, member of which is this user"
-                },
-                "totp_url": {
-                  "type": "string",
-                  "title": "[readonly][optional] one time password if setting (2fa) is enabled"
-                },
-                "contact": {
-                  "$ref": "#/definitions/apiObjectId",
-                  "description": "[optional] contact connected to this user",
-                  "title": "repeated Call calls = 13; // order by created_at\nrepeated Registration reged = 13; // order by register_last"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "created_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "updated_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "deleted_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "deleted_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "chat_name": {
-                  "type": "string",
-                  "description": "The \"chat_name\" field is used to store the name displayed externally on the platform.\nFor example, \"chat_name\" is shown when an agent connects to chats with clients."
-                },
-                "force_password_change": {
-                  "type": "boolean",
-                  "description": "When set to true, the user will be required to change their password on next login."
-                }
-              },
-              "title": "body: modifications/changes"
-            }
-          },
-          {
-            "name": "fields",
-            "description": "PATCH: partial update",
-            "in": "query",
-            "required": false,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi"
-          }
-        ],
-        "tags": [
-          "Users"
-        ]
-      },
-      "patch": {
-        "operationId": "UpdateUser2",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/apiUser"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "user.id",
-            "description": "Object ID",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "format": "int64"
-          },
-          {
-            "name": "user",
-            "description": "body: modifications/changes",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "title": "Caller-ID-Name: Display Name"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string",
-                  "title": "alphanumeric username (login)"
-                },
-                "password": {
-                  "type": "string"
-                },
-                "extension": {
-                  "type": "string",
-                  "title": "Caller-ID-Number:"
-                },
-                "presence": {
-                  "$ref": "#/definitions/apiUserPresence",
-                  "description": "string presence = 7; // unique set of \u003cuser\u003e presentity \u003cstatus:basic\u003e tuples open[ed]\n string status = 8; // short display status (short description)",
-                  "title": "CallerId caller = 5; // extension\nPresenceStatus presence = 8;"
-                },
-                "device": {
-                  "$ref": "#/definitions/apiObjectId",
-                  "title": "[optional] default device assigned ? WebRTC register ?"
-                },
-                "devices": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "description": "[editable] list of unique `regular` devices, attached to this user",
-                  "title": "map\u003cint64, string\u003e devices = 13;"
-                },
-                "hotdesks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "title": "[readonly] list of unique `hotdesk` devices, assigned to this user"
-                },
-                "profile": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "list of variables, assigned to this user as an environment unit"
-                },
-                "permissions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiPermission"
-                  },
-                  "title": "set of operational permission grants"
-                },
-                "license": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiLicenseUser"
-                  },
-                  "title": "list of unique licenses, granted to this user"
-                },
-                "roles": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/apiObjectId"
-                  },
-                  "title": "roles, member of which is this user"
-                },
-                "totp_url": {
-                  "type": "string",
-                  "title": "[readonly][optional] one time password if setting (2fa) is enabled"
-                },
-                "contact": {
-                  "$ref": "#/definitions/apiObjectId",
-                  "description": "[optional] contact connected to this user",
-                  "title": "repeated Call calls = 13; // order by created_at\nrepeated Registration reged = 13; // order by register_last"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "created_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "updated_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "deleted_at": {
-                  "type": "string",
-                  "format": "int64",
-                  "title": "unix",
-                  "readOnly": true
-                },
-                "deleted_by": {
-                  "$ref": "#/definitions/apiUserId",
-                  "title": "user",
-                  "readOnly": true
-                },
-                "chat_name": {
-                  "type": "string",
-                  "description": "The \"chat_name\" field is used to store the name displayed externally on the platform.\nFor example, \"chat_name\" is shown when an agent connects to chats with clients."
-                },
-                "force_password_change": {
-                  "type": "boolean",
-                  "description": "When set to true, the user will be required to change their password on next login."
-                }
-              },
-              "title": "body: modifications/changes"
-            }
-          },
-          {
-            "name": "fields",
-            "description": "PATCH: partial update",
-            "in": "query",
-            "required": false,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi"
-          }
-        ],
-        "tags": [
-          "Users"
         ]
       }
     },
@@ -16535,7 +16277,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/apiUser",
+          "$ref": "#/definitions/apiInputUser",
           "title": "user entity to be created"
         },
         "user_password": {
@@ -16940,6 +16682,100 @@
           "title": "repeated string privileges = 5; // [\"SEARCH\",\"MODIFY\",\"DELETE\",\"CREATE\"]\nbool grantable = 6; // WITH GRANT OPTION"
         }
       }
+    },
+    "apiInputUser": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Caller-ID-Name: Display Name"
+        },
+        "email": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string",
+          "title": "alphanumeric username (login)"
+        },
+        "password": {
+          "type": "string"
+        },
+        "extension": {
+          "type": "string",
+          "title": "Caller-ID-Number:"
+        },
+        "presence": {
+          "$ref": "#/definitions/apiUserPresence"
+        },
+        "device": {
+          "$ref": "#/definitions/apiObjectId",
+          "title": "[optional] default device assigned"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiObjectId"
+          },
+          "title": "[editable] list of unique `regular` devices, attached to this user"
+        },
+        "hotdesks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiObjectId"
+          },
+          "title": "[readonly] list of unique `hotdesk` devices, assigned to this user"
+        },
+        "profile": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "list of variables, assigned to this user as an environment unit"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiPermission"
+          },
+          "title": "set of operational permission grants"
+        },
+        "license": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiLicenseUser"
+          },
+          "title": "list of unique licenses, granted to this user"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiObjectId"
+          },
+          "title": "roles, member of which is this user"
+        },
+        "totp_url": {
+          "type": "string",
+          "title": "[readonly][optional] one time password if setting (2fa) is enabled"
+        },
+        "contact": {
+          "$ref": "#/definitions/apiObjectId",
+          "title": "[optional] contact connected to this user"
+        },
+        "chat_name": {
+          "type": "string",
+          "description": "The \"chat_name\" field is used to store the name displayed externally on the platform.\nFor example, \"chat_name\" is shown when an agent connects to chats with clients."
+        },
+        "force_password_change": {
+          "type": "boolean",
+          "description": "When set to true, the user will be required to change their password on next login."
+        }
+      },
+      "description": "Input of the User profile for Create/Update operations.\nMirrors `User` field numbers 1:1 (wire-compatible), but excludes\nsystem-managed read-only fields (id, audit metadata)."
     },
     "apiLDAPCatalog": {
       "type": "object",
@@ -18621,8 +18457,7 @@
         "id": {
           "type": "string",
           "format": "int64",
-          "title": "Object ID",
-          "readOnly": true
+          "title": "Object ID"
         },
         "name": {
           "type": "string",
@@ -18711,35 +18546,29 @@
         "created_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix",
-          "readOnly": true
+          "title": "unix"
         },
         "created_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user",
-          "readOnly": true
+          "title": "user"
         },
         "updated_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix",
-          "readOnly": true
+          "title": "unix"
         },
         "updated_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user",
-          "readOnly": true
+          "title": "user"
         },
         "deleted_at": {
           "type": "string",
           "format": "int64",
-          "title": "unix",
-          "readOnly": true
+          "title": "unix"
         },
         "deleted_by": {
           "$ref": "#/definitions/apiUserId",
-          "title": "user",
-          "readOnly": true
+          "title": "user"
         },
         "chat_name": {
           "type": "string",

--- a/webitel-go/users.proto
+++ b/webitel-go/users.proto
@@ -11,7 +11,6 @@ import "permission.proto";
 import "auth.proto";
 import "warnings.proto";
 import "google/api/annotations.proto";
-import "protoc-gen-openapiv2/options/annotations.proto";
 
 service Users {
 
@@ -25,11 +24,11 @@ service Users {
     }
     rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
         option (google.api.http) = {
-            put: "/users/{user.id}"
+            put: "/users/{id}"
             body: "user"
             response_body: "updated"
             additional_bindings {
-                patch: "/users/{user.id}"
+                patch: "/users/{id}"
                 body: "user"
                 response_body: "updated"
             }
@@ -95,9 +94,7 @@ message UserId {
 // User profile.
 message User {
 
-    int64  id = 1 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // Object ID
+    int64  id = 1; // Object ID
     string name = 2; // Caller-ID-Name: Display Name
 
     string email = 3;
@@ -134,24 +131,12 @@ message User {
     // repeated Registration reged = 13; // order by register_last
     ObjectId contact = 18; // [optional] contact connected to this user
 
-    int64  created_at = 20 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // unix
-    UserId created_by = 21 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // user
-    int64  updated_at = 22 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // unix
-    UserId updated_by = 23 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // user
-    int64  deleted_at = 24 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // unix
-    UserId deleted_by = 25 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ]; // user
+    int64  created_at = 20; // unix
+    UserId created_by = 21; // user
+    int64  updated_at = 22; // unix
+    UserId updated_by = 23; // user
+    int64  deleted_at = 24; // unix
+    UserId deleted_by = 25; // user
 
     // The "chat_name" field is used to store the name displayed externally on the platform.
     // For example, "chat_name" is shown when an agent connects to chats with clients.
@@ -162,14 +147,46 @@ message User {
 
 }
 
+// Input of the User profile for Create/Update operations.
+// Mirrors `User` field numbers 1:1 (wire-compatible), but excludes
+// system-managed read-only fields (id, audit metadata).
+message InputUser {
+    string name = 2; // Caller-ID-Name: Display Name
+
+    string email = 3;
+
+    string username = 4; // alphanumeric username (login)
+    string password = 5;
+
+    string extension = 6; // Caller-ID-Number:
+
+    UserPresence presence = 8;
+
+    ObjectId device = 10; // [optional] default device assigned
+    repeated ObjectId devices = 11; // [editable] list of unique `regular` devices, attached to this user
+    repeated ObjectId hotdesks = 12; // [readonly] list of unique `hotdesk` devices, assigned to this user
+
+    map<string,string> profile = 13; // list of variables, assigned to this user as an environment unit
+    repeated Permission permissions = 14; // set of operational permission grants
+    repeated LicenseUser license = 15; // list of unique licenses, granted to this user
+    repeated ObjectId roles = 16; // roles, member of which is this user
+
+    string totp_url = 17; // [readonly][optional] one time password if setting (2fa) is enabled
+
+    ObjectId contact = 18; // [optional] contact connected to this user
+
+    // The "chat_name" field is used to store the name displayed externally on the platform.
+    // For example, "chat_name" is shown when an agent connects to chats with clients.
+    string chat_name = 26;
+
+    // When set to true, the user will be required to change their password on next login.
+    bool force_password_change = 27;
+}
+
 message CreateUserRequest {
-    User   user = 1; // user entity to be created
-    string user_password = 2 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ];
-    string confirm_password = 3 [
-        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { read_only: true }
-    ];
+    InputUser user = 1; // user entity to be created
+    string user_password = 2;
+    string confirm_password = 3;
 }
 
 message CreateUserResponse {
@@ -186,8 +203,9 @@ message ReadUserResponse {
 }
 
 message UpdateUserRequest {
-    User user = 1; // body: modifications/changes
-    repeated string fields = 2; // PATCH: partial update
+    int64 id = 1; // path: /users/{id}
+    InputUser user = 2; // body: modifications/changes
+    repeated string fields = 3; // PATCH: partial update
 }
 
 message UpdateUserResponse {


### PR DESCRIPTION
## Проблема
У Swagger UI для `POST/PUT/PATCH /users` все ще відображались зайві поля `created_by`, `updated_by`, `deleted_by`, незважаючи на додані раніше `read_only: true` анотації (PR #314, WTEL-7795).

Причина - обмеження Swagger 2.0: специфікація ігнорує всі sibling-властивості поряд із `$ref`. Поля `created_by/updated_by/deleted_by` посилаються на `apiUserId` через `$ref`, тому `readOnly: true` поруч мовчки відкидається Swagger UI. Скалярні поля (`id`, `created_at`, `user_password` тощо) сховались коректно бо не використовують `$ref`.

## Вирішення
Замість боротьби з Swagger 2.0 застосовано канонічний для монорепо паттерн розділення Entity та Input message (як у `cases/priority.proto` з `InputPriority`, у `contacts/phones.proto` з `InputPhoneNumber`).

Створено окремий `InputUser` message що містить тільки редаговані поля, без id та audit-метаданих. Він використовується у `CreateUserRequest.user` та `UpdateUserRequest.user`. Поля фізично відсутні у схемі body, тому Swagger UI їх не показує у принципі.
