### PR TITLE
WTEL-9731: Remove languages field from contacts swagger.

### DIFF
--- a/swagger/webitel-go.swagger.json
+++ b/swagger/webitel-go.swagger.json
@@ -80,9 +80,6 @@
       "name": "Variables"
     },
     {
-      "name": "Languages"
-    },
-    {
       "name": "Timezones"
     },
     {
@@ -102,6 +99,9 @@
     },
     {
       "name": "Groups"
+    },
+    {
+      "name": "Languages"
     },
     {
       "name": "Timeline"
@@ -340,7 +340,7 @@
     "/contacts": {
       "get": {
         "summary": "Search for Contact(s)",
-        "description": "| Field       | Type \n| ----------- | ---- \n| **----------- READ-ONLY -----------** | \n| `id`        | int64 \n| `ver`       | int32 \n| `etag`      | string \n| **---------- OPERATIONAL ----------** | \n| `created_at` | int64(epoch:milli) \n| `created_by` | lookup(user) \n| `updated_at` | int64(epoch:milli) \n| `updated_by` | lookup(user) \n| **---------- ATTRIBUTES -----------** | \n| `name`      | name! \n| `about`     | string \n| `labels`    | list[label!] \n| `emails`    | list[email!] \n| `photos`    | list[photo!] \n| `phones`    | list[phone!] \n| `managers`  | list[manager!] \n| `comments`  | list[comment!] \n| `addresses` | list[address!] \n| `languages` | list[language!] \n| `timezones` | list[timezone!] \n| `variables` | list[variable!] \n| `imclients` | list[imClient!] \n",
+        "description": "| Field       | Type \n| ----------- | ---- \n| **----------- READ-ONLY -----------** | \n| `id`        | int64 \n| `ver`       | int32 \n| `etag`      | string \n| **---------- OPERATIONAL ----------** | \n| `created_at` | int64(epoch:milli) \n| `created_by` | lookup(user) \n| `updated_at` | int64(epoch:milli) \n| `updated_by` | lookup(user) \n| **---------- ATTRIBUTES -----------** | \n| `name`      | name! \n| `about`     | string \n| `labels`    | list[label!] \n| `emails`    | list[email!] \n| `photos`    | list[photo!] \n| `phones`    | list[phone!] \n| `managers`  | list[manager!] \n| `comments`  | list[comment!] \n| `addresses` | list[address!] \n| `timezones` | list[timezone!] \n| `variables` | list[variable!] \n| `imclients` | list[imClient!] \n",
         "operationId": "SearchContacts",
         "responses": {
           "200": {
@@ -6700,14 +6700,6 @@
                     "$ref": "#/definitions/contactsInputComment"
                   },
                   "description": "Publish NEW comment(s) for this Contact."
-                },
-                "languages": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "$ref": "#/definitions/contactsInputLanguage"
-                  },
-                  "description": "A Contact's locale preference(s)."
                 },
                 "timezones": {
                   "type": "array",
@@ -20368,14 +20360,6 @@
           },
           "description": "Publish NEW comment(s) for this Contact."
         },
-        "languages": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/contactsInputLanguage"
-          },
-          "description": "A Contact's locale preference(s)."
-        },
         "timezones": {
           "type": "array",
           "items": {
@@ -22641,10 +22625,6 @@
         "comments": {
           "$ref": "#/definitions/contactsCommentList",
           "description": "The Contact's internal comment(s)."
-        },
-        "languages": {
-          "$ref": "#/definitions/contactsLanguageList",
-          "description": "A Contact's locale preference(s)."
         },
         "timezones": {
           "$ref": "#/definitions/contactsTimezoneList",

--- a/webitel-go/contacts/contact.proto
+++ b/webitel-go/contacts/contact.proto
@@ -10,7 +10,6 @@ import "contacts/phones.proto";
 import "contacts/managers.proto";
 import "contacts/comments.proto";
 import "contacts/variables.proto";
-import "contacts/languages.proto";
 import "contacts/timezones.proto";
 // import "contacts/addresses.proto";
 import "contacts/imclients.proto";
@@ -222,7 +221,7 @@ message Contact {
 
   // option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
   //   // GET /contacts/{id}
-  //   example: "{\"id\":\"4\",\"ver\":\"16\",\"etag\":\"qZN3pKzHVQf4XkG7\",\"created_at\":\"1680268507698\",\"created_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"updated_at\":\"1680348682359\",\"updated_by\":{\"id\":\"37\",\"name\":\"Bruce Wayne\"},\"names\":{\"data\":[{\"id\":\"4\",\"ver\":\"4\",\"etag\":\"qZN3pKzHVQf4XkG7\",\"updated_at\":\"1680348672359\",\"updated_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"primary\":true,\"verified\":true,\"common_name\":\"Johnny Doe\",\"given_name\":\"John\",\"middle_name\":\"Ashton\",\"family_name\":\"Doe\"}]},\"labels\":{\"data\":[{\"tag\":\"user\"},{\"tag\":\"VIP\"}]},\"emails\":{\"data\":[{\"primary\":true,\"verified\":false,\"email\":\"j.doe@example.com\",\"type\":{\"id\":\"5\",\"name\":\"work\"}},{\"verified\":true,\"email\":\"johnny43@mx.example.org\",\"type\":{\"name\":\"fake\"}}],\"page\":1,\"next\":true},\"phones\":{\"data\":[{\"primary\":true,\"verified\":false,\"number\":\"+1 (484) 476-0186\",\"type\":{\"id\":\"5\",\"name\":\"work\"}}]},\"languages\":{\"data\":[{\"primary\":true,\"lang\":\"en-GB\"},{\"lang\":\"uk\"}]},\"timezones\":{\"data\":[{\"primary\":true,\"location\":\"Europe/London\"}]},\"variables\":{\"data\":[{\"key\":\"string_var\",\"value\":\"string_value\"},{\"key\":\"complex_var\",\"value\":{\"integer\":54642354,\"inner_arr\":[\"string_item\",[null],true,{}]}}],\"page\":1,\"next\":true},\"imclients\":{\"data\":[]},\"comments\":{\"data\":[{\"id\":\"354\",\"etag\":\"FqaTCDLbhpaoUreL\",\"created_at\":\"1680268507698\",\"created_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"text\":\"This is an internal note about recent activities.\"},{\"id\":\"357\",\"ver\":\"4\",\"etag\":\"FZiTxVgr41VPFxyu\",\"created_at\":\"1680268537698\",\"created_by\":{\"id\":\"56\",\"name\":\"Bruce Wayne\"},\"updated_at\":\"1680268563357\",\"updated_by\":{\"name\":\"Jane Lee (deleted)\"},\"text\":\"This contact may become a customer in a few days\"}],\"page\":1,\"next\":true}}"
+  //   example: "{\"id\":\"4\",\"ver\":\"16\",\"etag\":\"qZN3pKzHVQf4XkG7\",\"created_at\":\"1680268507698\",\"created_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"updated_at\":\"1680348682359\",\"updated_by\":{\"id\":\"37\",\"name\":\"Bruce Wayne\"},\"names\":{\"data\":[{\"id\":\"4\",\"ver\":\"4\",\"etag\":\"qZN3pKzHVQf4XkG7\",\"updated_at\":\"1680348672359\",\"updated_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"primary\":true,\"verified\":true,\"common_name\":\"Johnny Doe\",\"given_name\":\"John\",\"middle_name\":\"Ashton\",\"family_name\":\"Doe\"}]},\"labels\":{\"data\":[{\"tag\":\"user\"},{\"tag\":\"VIP\"}]},\"emails\":{\"data\":[{\"primary\":true,\"verified\":false,\"email\":\"j.doe@example.com\",\"type\":{\"id\":\"5\",\"name\":\"work\"}},{\"verified\":true,\"email\":\"johnny43@mx.example.org\",\"type\":{\"name\":\"fake\"}}],\"page\":1,\"next\":true},\"phones\":{\"data\":[{\"primary\":true,\"verified\":false,\"number\":\"+1 (484) 476-0186\",\"type\":{\"id\":\"5\",\"name\":\"work\"}}]},\"timezones\":{\"data\":[{\"primary\":true,\"location\":\"Europe/London\"}]},\"variables\":{\"data\":[{\"key\":\"string_var\",\"value\":\"string_value\"},{\"key\":\"complex_var\",\"value\":{\"integer\":54642354,\"inner_arr\":[\"string_item\",[null],true,{}]}}],\"page\":1,\"next\":true},\"imclients\":{\"data\":[]},\"comments\":{\"data\":[{\"id\":\"354\",\"etag\":\"FqaTCDLbhpaoUreL\",\"created_at\":\"1680268507698\",\"created_by\":{\"id\":\"34\",\"name\":\"John Doe\"},\"text\":\"This is an internal note about recent activities.\"},{\"id\":\"357\",\"ver\":\"4\",\"etag\":\"FZiTxVgr41VPFxyu\",\"created_at\":\"1680268537698\",\"created_by\":{\"id\":\"56\",\"name\":\"Bruce Wayne\"},\"updated_at\":\"1680268563357\",\"updated_by\":{\"name\":\"Jane Lee (deleted)\"},\"text\":\"This contact may become a customer in a few days\"}],\"page\":1,\"next\":true}}"
   // };
 
   // [TUPLE]: --------------------------------------
@@ -293,8 +292,7 @@ message Contact {
   // The Contact's internal comment(s).
   webitel.contacts.CommentList comments = 28;
 
-  // A Contact's locale preference(s).
-  webitel.contacts.LanguageList languages = 29;
+  reserved 29; reserved "languages";
   // The Contact's timezone preference(s).
   webitel.contacts.TimezoneList timezones = 30;
   // The Contact's associated group(s).
@@ -382,8 +380,7 @@ message InputContact {
   // Publish NEW comment(s) for this Contact.
   repeated webitel.contacts.InputComment comments = 28;
 
-  // A Contact's locale preference(s).
-  repeated webitel.contacts.InputLanguage languages = 29;
+  reserved 29; reserved "languages";
 
   // The Contact's timezone preference(s).
   repeated webitel.contacts.InputTimezone timezones = 30;

--- a/webitel-go/contacts/contacts.proto
+++ b/webitel-go/contacts/contacts.proto
@@ -54,7 +54,6 @@ service Contacts {
       "| `managers`  | list[manager!] \n"
       "| `comments`  | list[comment!] \n"
       "| `addresses` | list[address!] \n"
-      "| `languages` | list[language!] \n"
       "| `timezones` | list[timezone!] \n"
       "| `variables` | list[variable!] \n"
       "| `imclients` | list[imClient!] \n"


### PR DESCRIPTION
## Зміни
- Синхронізовано `webitel-go/contacts/contact.proto` та `contacts.proto` з webitel.go після видалення неробочого поля `languages` 