### PR TITLE
WTEL-9850 [chat audit]

### DIFF
--- a/chat/messages/dialog.proto
+++ b/chat/messages/dialog.proto
@@ -57,6 +57,8 @@ message Dialog {
   string closed_cause = 13;
   // OPTIONAL. Last dialog queue
   Peer queue = 14;
+  // Zero value means - NOT rated yet.
+  int64 rate_id = 15;
 
 }
 

--- a/swagger/messages.swagger.json
+++ b/swagger/messages.swagger.json
@@ -1759,6 +1759,11 @@
         "queue": {
           "$ref": "#/definitions/webitel.chat.Peer",
           "title": "OPTIONAL. Last dialog queue"
+        },
+        "rate_id": {
+          "type": "string",
+          "format": "int64",
+          "description": "Zero value means - NOT rated yet."
         }
       },
       "description": "Chat Dialog. Conversation info."


### PR DESCRIPTION
fix: add rate_id to chat/dialogs response