### PR TITLE
WTEL-10099 [export members]

### DIFF
--- a/engine/member.proto
+++ b/engine/member.proto
@@ -40,6 +40,11 @@ service MemberService {
   rpc SearchMemberInQueue(SearchMemberInQueueRequest) returns (ListMember) {
     option (google.api.http) = {get: "/call_center/queues/{queue_id}/members"};
   }
+
+  // Export Members of a queue as CSV or XLSX, streamed in chunks
+  rpc ExportMembers(ExportMembersRequest) returns (stream ExportMembersResponse) {
+    option (google.api.http) = {get: "/call_center/queues/{queue_id}/members/export"};
+  }
   // ReadQueueRouting
   rpc ReadMember(ReadMemberRequest) returns (MemberInQueue) {
     option (google.api.http) = {get: "/call_center/queues/{queue_id}/members/{id}"};
@@ -634,6 +639,35 @@ message SearchMemberInQueueRequest {
 message ListMember {
   bool next = 1;
   repeated MemberInQueue items = 2;
+}
+
+message ExportMembersRequest {
+  int32 queue_id = 1;
+  string q = 2;
+  repeated string fields = 3;
+
+  repeated int64 id = 4;
+  repeated int32 bucket_id = 5;
+  string destination = 6;
+
+  FilterBetween created_at = 7;
+  FilterBetween offering_at = 8;
+  repeated string stop_cause = 9;
+  FilterBetween priority = 10;
+  string name = 11;
+  FilterBetween attempts = 12;
+  repeated int32 agent_id = 13;
+  map<string, string> variables = 14;
+
+  // Export format: csv or xlsx
+  string format = 15;
+  // Column separator, used only when format is csv
+  string separator = 16;
+}
+
+message ExportMembersResponse {
+  // File data chunk
+  bytes data = 1;
 }
 
 message CreateMemberRequest {

--- a/swagger/engine.swagger.json
+++ b/swagger/engine.swagger.json
@@ -6661,6 +6661,195 @@
         ]
       }
     },
+    "/call_center/queues/{queue_id}/members/export": {
+      "get": {
+        "summary": "Export Members of a queue as CSV or XLSX, streamed in chunks",
+        "operationId": "ExportMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/engine.ExportMembersResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of engine.ExportMembersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "bucket_id",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "destination",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "created_at.from",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "created_at.to",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "offering_at.from",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "offering_at.to",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "stop_cause",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "priority.from",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "priority.to",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "attempts.from",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "attempts.to",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "variables[string]",
+            "description": "This is a request variable of the map type. The query format is \"map_name[key]=value\", e.g. If the map name is Age, the key type is string, and the value type is integer, the query parameter is expressed as Age[\"bob\"]=18",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "format",
+            "description": "Export format: csv or xlsx",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "separator",
+            "description": "Column separator, used only when format is csv",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "MemberService"
+        ]
+      }
+    },
     "/call_center/queues/{queue_id}/members/reset": {
       "patch": {
         "summary": "ResetMembers",
@@ -19291,6 +19480,16 @@
         "work_stop": {
           "type": "integer",
           "format": "int32"
+        }
+      }
+    },
+    "engine.ExportMembersResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "title": "File data chunk"
         }
       }
     },


### PR DESCRIPTION
feat: add new endpoint that return all queue members in csv/xlsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to export queue members through a downloadable streaming endpoint.
  * Supports CSV and XLSX export formats.
  * Added member filtering options for exports.
  * CSV exports support a customizable separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->